### PR TITLE
Use plugin permissions system on infinity stones

### DIFF
--- a/InfinityStones/src/mclstones/Main.java
+++ b/InfinityStones/src/mclstones/Main.java
@@ -228,7 +228,7 @@ public class Main extends JavaPlugin implements Listener
         @Override
         public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args)
         {
-            if (sender.isOp())
+            if (sender.hasPermission("thanos"))
             {
                 if (args.length >= 1)
                 {
@@ -248,7 +248,7 @@ public class Main extends JavaPlugin implements Listener
 
 
             }
-            else sender.sendMessage("Only operators can use this command");
+            else sender.sendMessage("Only authorized users can use this command");
 
             return true;
         }

--- a/InfinityStones/src/plugin.yml
+++ b/InfinityStones/src/plugin.yml
@@ -5,5 +5,8 @@ main: mclstones.Main
 api-version: 1.13
 commands:
   thanos:
-    description: Spawn the Infinity Stones (Must be OP)
+    description: Spawn the Infinity Stones (Must have permission)
     usage: /thanos <player>
+permissions:
+  thanos:
+    description: Allows spawn the Infinity Stones


### PR DESCRIPTION
Some servers have op disabled and rely on permissions plugins, that makes the plugin unusable there.
This is a simple change and will still work if you're op, the change it's tested and seems to work as intended.

Nice plugin idea, thanks.